### PR TITLE
`.conda` packages in `repodata.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,26 @@ list of the packages metadata in platform directory and subdir where package is 
       "timestamp": 1530731681870,
       "version": "0.1.0"
     }
+  },
+  "packages.conda": {
+    "super-fun-package-0.2.0-py37_0.conda": {
+      "build": "py37_0",
+      "build_number": 0,
+      "depends": [
+        "some-depends"
+      ],
+      "license": "BSD",
+      "md5": "a75683f8d9f5b58c19a8ec5d0b7f797e",
+      "name": "super-fun-package",
+      "sha256": "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5811f",
+      "size": 3832,
+      "subdir": "win-64",
+      "timestamp": 1530731681860,
+      "version": "0.2.0"
+    }
   }
 }
 ```
+`tar.bz2` packages are listed under `packages` element, `.conda` packages are listed under 
+`packages.conda` element. `Repodata.json` can also contain some other info 
+(for example, subdir name) on the root level.

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,12 @@ SOFTWARE.
       <version>1.7.30</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <testResources>

--- a/src/main/java/com/artipie/conda/meta/JsonMaid.java
+++ b/src/main/java/com/artipie/conda/meta/JsonMaid.java
@@ -54,12 +54,10 @@ public interface JsonMaid {
         @Override
         @SuppressWarnings("PMD.AssignmentInOperand")
         public void clean(final Set<String> checksums) throws IOException {
-            this.gnrt.writeStartObject();
-            this.gnrt.writeFieldName("packages");
-            this.gnrt.writeStartObject();
             JsonToken token;
             while ((token = this.parser.nextToken()) != null) {
                 if (token == JsonToken.FIELD_NAME
+                    && !"packages.conda".equals(this.parser.getCurrentName())
                     && (this.parser.getCurrentName().endsWith("tar.bz2")
                         || this.parser.getCurrentName().endsWith(".conda"))) {
                     final String name = this.parser.getCurrentName();
@@ -71,6 +69,8 @@ public interface JsonMaid {
                         this.gnrt.setCodec(new ObjectMapper());
                         this.gnrt.writeTree(nodes);
                     }
+                } else {
+                    this.gnrt.copyCurrentEvent(this.parser);
                 }
             }
             this.gnrt.close();

--- a/src/test/com/artipie/conda/CondaRepodataRemoveTest.java
+++ b/src/test/com/artipie/conda/CondaRepodataRemoveTest.java
@@ -26,7 +26,10 @@ class CondaRepodataRemoveTest {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             new CondaRepodata.Remove(input, out).perform(
                 new SetOf<>(
-                    "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f", "xyx123"
+                    "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+                    "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+                    "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+                    "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"
                 )
             );
             MatcherAssert.assertThat(
@@ -36,22 +39,21 @@ class CondaRepodataRemoveTest {
                         "",
                         "{",
                         "\"packages\":{",
-                        "\"test-package-0.5.0-py36_0.conda\":{",
-                        "\"build\":\"py37_0\",",
+                        "\"decorator-4.2.1-py27_0.tar.bz2\":{",
+                        "\"build\":\"py27_0\",",
                         "\"build_number\":0,",
-                        "\"depends\":[\"some-depends\"],",
-                        "\"license\":\"BSD\",",
-                        "\"md5\":\"a75683f8d9f5b58c19a8ec5d0b7f786e\",",
-                        "\"name\":\"test-package\",",
+                        "\"depends\":[\"python >=2.7,<2.8.0a0\"],",
+                        "\"license\":\"BSD 3-Clause\",",
+                        "\"md5\":\"0ebe0cb0d62eae6cd237444ba8fded66\",",
+                        "\"name\":\"decorator\",",
                         // @checkstyle LineLengthCheck (1 line)
-                        "\"sha256\":\"1fe3c3f4250e51886838e8e0287e39076d601b9f493ea05c37a2630a9fe5810f\",",
-                        "\"size\":123,",
-                        "\"subdir\":\"macOS\",",
-                        "\"timestamp\":153073163434,",
-                        "\"version\":\"0.5.0\"",
-                        "}",
-                        "}",
-                        "}"
+                        "\"sha256\":\"b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14\",",
+                        "\"size\":15638,",
+                        "\"subdir\":\"linux-64\",",
+                        "\"timestamp\":1516376429792,",
+                        "\"version\":\"4.2.1\"",
+                        "}}",
+                        ",\"packages.conda\":{}}"
                     )
                 )
             );

--- a/src/test/com/artipie/conda/CondaRepodataRemoveTest.java
+++ b/src/test/com/artipie/conda/CondaRepodataRemoveTest.java
@@ -10,9 +10,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import org.cactoos.set.SetOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Test for {@link CondaRepodata.Remove}.
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 class CondaRepodataRemoveTest {
 
     @Test
-    void removesPackagesInfo() throws IOException {
+    void removesPackagesInfo() throws IOException, JSONException {
         try (InputStream input = new TestResource("repodata.json").asInputStream()) {
             final ByteArrayOutputStream out = new ByteArrayOutputStream();
             new CondaRepodata.Remove(input, out).perform(
@@ -32,44 +32,42 @@ class CondaRepodataRemoveTest {
                     "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"
                 )
             );
-            MatcherAssert.assertThat(
+            JSONAssert.assertEquals(
                 out.toString(),
-                new IsEqual<>(
-                    String.join(
-                        "",
-                        "{",
-                        "\"packages\":{",
-                        "\"decorator-4.2.1-py27_0.tar.bz2\":{",
-                        "\"build\":\"py27_0\",",
-                        "\"build_number\":0,",
-                        "\"depends\":[\"python >=2.7,<2.8.0a0\"],",
-                        "\"license\":\"BSD 3-Clause\",",
-                        "\"md5\":\"0ebe0cb0d62eae6cd237444ba8fded66\",",
-                        "\"name\":\"decorator\",",
-                        // @checkstyle LineLengthCheck (1 line)
-                        "\"sha256\":\"b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14\",",
-                        "\"size\":15638,",
-                        "\"subdir\":\"linux-64\",",
-                        "\"timestamp\":1516376429792,",
-                        "\"version\":\"4.2.1\"",
-                        "}}",
-                        ",\"packages.conda\":{}}"
-                    )
-                )
+                String.join(
+                    "",
+                    "{",
+                    "\"packages\":{",
+                    "\"decorator-4.2.1-py27_0.tar.bz2\":{",
+                    "\"build\":\"py27_0\",",
+                    "\"build_number\":0,",
+                    "\"depends\":[\"python >=2.7,<2.8.0a0\"],",
+                    "\"license\":\"BSD 3-Clause\",",
+                    "\"md5\":\"0ebe0cb0d62eae6cd237444ba8fded66\",",
+                    "\"name\":\"decorator\",",
+                    // @checkstyle LineLengthCheck (1 line)
+                    "\"sha256\":\"b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14\",",
+                    "\"size\":15638,",
+                    "\"subdir\":\"linux-64\",",
+                    "\"timestamp\":1516376429792,",
+                    "\"version\":\"4.2.1\"",
+                    "}}",
+                    ",\"packages.conda\":{}}"
+                ),
+                true
             );
         }
     }
 
     @Test
-    void doesNothingIfGivenFileIsEmpty() {
+    void doesNothingIfGivenFileIsEmpty() throws JSONException {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final String file = "{\"packages\":{}}";
         new CondaRepodata.Remove(
             new ByteArrayInputStream(file.getBytes()), out
         ).perform(new SetOf<>("abc123", "xyx098"));
-        MatcherAssert.assertThat(
-            out.toString(),
-            new IsEqual<>(file)
+        JSONAssert.assertEquals(
+            out.toString(), file, true
         );
     }
 

--- a/src/test/com/artipie/conda/meta/JsonMaidTest.java
+++ b/src/test/com/artipie/conda/meta/JsonMaidTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
  * Test for {@link JsonMaid.Jackson}.
  * @since 0.1
  */
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.TooManyMethods"})
 class JsonMaidTest {
 
     @Test
@@ -165,7 +165,6 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(new SetOf<String>("098"));
-        final String res = stream.toString();
         MatcherAssert.assertThat(
             stream.toByteArray(),
             new IsEqual<>(resource.asBytes())
@@ -234,6 +233,7 @@ class JsonMaidTest {
             "    \"pyqt-5.6.0-py36h0386399_5.tar.bz2\" : {",
             "      \"build\" : \"py36h0386399_5\",",
             "      \"build_number\" : 5,",
+            // @checkstyle LineLengthCheck (1 line)
             "      \"depends\" : [ \"dbus >=1.10.22,<2.0a0\", \"libgcc-ng >=7.2.0\", \"libstdcxx-ng >=7.2.0\", \"python >=3.6,<3.7.0a0\", \"qt 5.6.*\", \"sip 4.18.*\" ],",
             "      \"license\" : \"Commercial, GPL-2.0, GPL-3.0\",",
             "      \"license_family\" : \"GPL\",",
@@ -263,6 +263,7 @@ class JsonMaidTest {
             "      \"app_type\" : \"web\",",
             "      \"build\" : \"py38_0\",",
             "      \"build_number\" : 0,",
+            // @checkstyle LineLengthCheck (1 line)
             "      \"depends\" : [ \"argon2-cffi\", \"ipykernel\", \"ipython_genutils\", \"jinja2\", \"send2trash\", \"terminado >=0.8.1\", \"tornado >=5.0\", \"traitlets >=4.2.1\" ],",
             "      \"icon\" : \"df7feebede9861a203b480c119e38b49.png\",",
             "      \"license\" : \"BSD-3-Clause\",",

--- a/src/test/com/artipie/conda/meta/JsonMaidTest.java
+++ b/src/test/com/artipie/conda/meta/JsonMaidTest.java
@@ -22,21 +22,31 @@ import org.junit.jupiter.api.Test;
 class JsonMaidTest {
 
     @Test
-    void removedPackage() throws IOException {
+    void removedPackages() throws IOException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
         new JsonMaid.Jackson(
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
-        ).clean(new SetOf<>("1fe3c3f4250e51886838e8e0287e39076d601b9f493ea05c37a2630a9fe5810f"));
+        ).clean(
+            new SetOf<>(
+                "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+                "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e"
+            )
+        );
+        final String actual = stream.toString();
         MatcherAssert.assertThat(
-            stream.toString(),
+            actual,
             new IsEqual<>(
                 String.join(
                     "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s", this.funPackageZeroOne(), this.funPackageZeroTwo()),
-                    "  }", "}"
+                    String.format("%s,\n%s", this.cram(), this.decorator()),
+                    "  },",
+                    "  \"packages.conda\" : {",
+                    this.tenacity(),
+                    "  }",
+                    "}"
                 )
             )
         );
@@ -50,13 +60,16 @@ class JsonMaidTest {
         new JsonMaid.Jackson(
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
-        ).clean(new SetOf<>("xyx123"));
+        ).clean(new SetOf<>("47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"));
         MatcherAssert.assertThat(
             stream.toString(),
             new IsEqual<>(
                 String.join(
                     "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s", this.funPackageZeroOne(), this.testPackage()),
+                    String.format("%s,\n%s,\n%s", this.cram(), this.decorator(), this.pyqt()),
+                    "  },",
+                    "  \"packages.conda\" : {",
+                    this.notebook(),
                     "  }", "}"
                 )
             )
@@ -71,16 +84,72 @@ class JsonMaidTest {
         new JsonMaid.Jackson(
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
-        ).clean(new SetOf<>("1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f"));
+        ).clean(new SetOf<>("4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08"));
         MatcherAssert.assertThat(
             stream.toString(),
             new IsEqual<>(
                 String.join(
-                    "\n",
-                    "{",
-                    "  \"packages\" : {",
-                    String.format("%s,\n%s", this.testPackage(), this.funPackageZeroTwo()),
-                    "  }",
+                    "\n", "{", "  \"packages\" : {",
+                    String.format("%s,\n%s", this.decorator(), this.pyqt()),
+                    "  },",
+                    "  \"packages.conda\" : {",
+                    String.format("%s,\n%s", this.notebook(), this.tenacity()),
+                    "  }", "}"
+                )
+            )
+        );
+    }
+
+    @Test
+    void removesAllTarPackages() throws IOException {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final JsonFactory factory = new JsonFactory();
+        final TestResource resource = new TestResource("repodata.json");
+        new JsonMaid.Jackson(
+            factory.createGenerator(stream).useDefaultPrettyPrinter(),
+            factory.createParser(resource.asInputStream())
+        ).clean(
+            new SetOf<>(
+                "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+                "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+                "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a"
+            )
+        );
+        MatcherAssert.assertThat(
+            stream.toString(),
+            new IsEqual<>(
+                String.join(
+                    "\n", "{", "  \"packages\" : { },",
+                    "  \"packages.conda\" : {",
+                    String.format("%s,\n%s", this.notebook(), this.tenacity()),
+                    "  }", "}"
+                )
+            )
+        );
+    }
+
+    @Test
+    void removesAllCondaPackages() throws IOException {
+        final ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        final JsonFactory factory = new JsonFactory();
+        final TestResource resource = new TestResource("repodata.json");
+        new JsonMaid.Jackson(
+            factory.createGenerator(stream).useDefaultPrettyPrinter(),
+            factory.createParser(resource.asInputStream())
+        ).clean(
+            new SetOf<>(
+                "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+                "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"
+            )
+        );
+        MatcherAssert.assertThat(
+            stream.toString(),
+            new IsEqual<>(
+                String.join(
+                    "\n", "{", "  \"packages\" : {",
+                    String.format("%s,\n%s,\n%s", this.cram(), this.decorator(), this.pyqt()),
+                    "  },",
+                    "  \"packages.conda\" : { }",
                     "}"
                 )
             )
@@ -96,6 +165,7 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(new SetOf<String>("098"));
+        final String res = stream.toString();
         MatcherAssert.assertThat(
             stream.toByteArray(),
             new IsEqual<>(resource.asBytes())
@@ -117,61 +187,116 @@ class JsonMaidTest {
         );
     }
 
-    private String funPackageZeroTwo() {
+    private String cram() {
         return String.join(
             "\n",
-            "    \"super-fun-package-0.2.0-py37_0.tar.bz2\" : {",
-            "      \"build\" : \"py37_0\",",
-            "      \"build_number\" : 0,",
-            "      \"depends\" : [ \"some-depends\" ],",
-            "      \"license\" : \"BSD\",",
-            "      \"md5\" : \"abc123\",",
-            "      \"name\" : \"super-fun-package\",",
-            "      \"sha256\" : \"xyx123\",",
-            "      \"size\" : 3832,",
-            "      \"subdir\" : \"win-64\",",
-            "      \"timestamp\" : 1530731681870,",
-            "      \"version\" : \"0.2.0\"",
+            "    \"cram-0.7-py36_1.tar.bz2\" : {",
+            "      \"build\" : \"py36_1\",",
+            "      \"build_number\" : 1,",
+            "      \"depends\" : [ \"python >=3.6,<3.7.0a0\" ],",
+            "      \"license\" : \"GPL-2.0\",",
+            "      \"license_family\" : \"GPL2\",",
+            "      \"md5\" : \"609e6545899d1d098f4160dd98fbc74d\",",
+            "      \"name\" : \"cram\",",
+            // @checkstyle LineLengthCheck (1 line)
+            "      \"sha256\" : \"4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08\",",
+            "      \"size\" : 40151,",
+            "      \"subdir\" : \"linux-64\",",
+            "      \"timestamp\" : 1539182927005,",
+            "      \"version\" : \"0.7\"",
             "    }"
         );
     }
 
-    private String funPackageZeroOne() {
+    private String decorator() {
         return String.join(
             "\n",
-            "    \"super-fun-package-0.1.0-py37_0.tar.bz2\" : {",
-            "      \"build\" : \"py37_0\",",
+            "    \"decorator-4.2.1-py27_0.tar.bz2\" : {",
+            "      \"build\" : \"py27_0\",",
             "      \"build_number\" : 0,",
-            "      \"depends\" : [ \"some-depends\" ],",
-            "      \"license\" : \"BSD\",",
-            "      \"md5\" : \"a75683f8d9f5b58c19a8ec5d0b7f796e\",",
-            "      \"name\" : \"super-fun-package\",",
+            "      \"depends\" : [ \"python >=2.7,<2.8.0a0\" ],",
+            "      \"license\" : \"BSD 3-Clause\",",
+            "      \"md5\" : \"0ebe0cb0d62eae6cd237444ba8fded66\",",
+            "      \"name\" : \"decorator\",",
             // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f\",",
-            "      \"size\" : 3832,",
-            "      \"subdir\" : \"win-64\",",
-            "      \"timestamp\" : 1530731681870,",
-            "      \"version\" : \"0.1.0\"",
+            "      \"sha256\" : \"b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14\",",
+            "      \"size\" : 15638,",
+            "      \"subdir\" : \"linux-64\",",
+            "      \"timestamp\" : 1516376429792,",
+            "      \"version\" : \"4.2.1\"",
             "    }"
         );
     }
 
-    private String testPackage() {
+    private String pyqt() {
         return String.join(
             "\n",
-            "    \"test-package-0.5.0-py36_0.conda\" : {",
+            "    \"pyqt-5.6.0-py36h0386399_5.tar.bz2\" : {",
+            "      \"build\" : \"py36h0386399_5\",",
+            "      \"build_number\" : 5,",
+            "      \"depends\" : [ \"dbus >=1.10.22,<2.0a0\", \"libgcc-ng >=7.2.0\", \"libstdcxx-ng >=7.2.0\", \"python >=3.6,<3.7.0a0\", \"qt 5.6.*\", \"sip 4.18.*\" ],",
+            "      \"license\" : \"Commercial, GPL-2.0, GPL-3.0\",",
+            "      \"license_family\" : \"GPL\",",
+            "      \"md5\" : \"b1624f76a6bba705869f849f7456bd39\",",
+            "      \"name\" : \"pyqt\",",
+            // @checkstyle LineLengthCheck (1 line)
+            "      \"sha256\" : \"b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a\",",
+            "      \"size\" : 5715107,",
+            "      \"subdir\" : \"linux-64\",",
+            "      \"timestamp\" : 1505739175210,",
+            "      \"version\" : \"5.6.0\"",
+            "    }"
+        );
+    }
+
+    private String notebook() {
+        return String.join(
+            "\n",
+            "    \"notebook-6.1.1-py38_0.conda\" : {",
+            "      \"app_cli_opts\" : [ {",
+            "        \"args\" : \"--port %s\",",
+            "        \"default\" : \"8080\",",
+            "        \"name\" : \"port\",",
+            "        \"summary\" : \"Server port ...\"",
+            "      } ],",
+            "      \"app_entry\" : \"jupyter-notebook\",",
+            "      \"app_type\" : \"web\",",
+            "      \"build\" : \"py38_0\",",
+            "      \"build_number\" : 0,",
+            "      \"depends\" : [ \"argon2-cffi\", \"ipykernel\", \"ipython_genutils\", \"jinja2\", \"send2trash\", \"terminado >=0.8.1\", \"tornado >=5.0\", \"traitlets >=4.2.1\" ],",
+            "      \"icon\" : \"df7feebede9861a203b480c119e38b49.png\",",
+            "      \"license\" : \"BSD-3-Clause\",",
+            "      \"license_family\" : \"BSD\",",
+            "      \"md5\" : \"0a90b675d8e46db6dd92b48f085df274\",",
+            "      \"name\" : \"notebook\",",
+            // @checkstyle LineLengthCheck (1 line)
+            "      \"sha256\" : \"be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e\",",
+            "      \"size\" : 4233953,",
+            "      \"subdir\" : \"linux-64\",",
+            "      \"summary\" : \"Jupyter Notebook\",",
+            "      \"timestamp\" : 1596838674769,",
+            "      \"type\" : \"app\",",
+            "      \"version\" : \"6.1.1\"",
+            "    }"
+        );
+    }
+
+    private String tenacity() {
+        return String.join(
+            "\n",
+            "    \"tenacity-6.2.0-py37_0.conda\" : {",
             "      \"build\" : \"py37_0\",",
             "      \"build_number\" : 0,",
-            "      \"depends\" : [ \"some-depends\" ],",
-            "      \"license\" : \"BSD\",",
-            "      \"md5\" : \"a75683f8d9f5b58c19a8ec5d0b7f786e\",",
-            "      \"name\" : \"test-package\",",
+            "      \"depends\" : [ \"python >=3.7,<3.8.0a0\", \"six >=1.9.0\" ],",
+            "      \"license\" : \"Apache 2.0\",",
+            "      \"md5\" : \"e5a8af970f391f432c96b1480f535c43\",",
+            "      \"name\" : \"tenacity\",",
             // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"1fe3c3f4250e51886838e8e0287e39076d601b9f493ea05c37a2630a9fe5810f\",",
-            "      \"size\" : 123,",
-            "      \"subdir\" : \"macOS\",",
-            "      \"timestamp\" : 153073163434,",
-            "      \"version\" : \"0.5.0\"",
+            "      \"sha256\" : \"47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f\",",
+            "      \"size\" : 40072,",
+            "      \"subdir\" : \"linux-64\",",
+            "      \"timestamp\" : 1597706734992,",
+            "      \"version\" : \"6.2.0\"",
             "    }"
         );
     }

--- a/src/test/com/artipie/conda/meta/JsonMaidTest.java
+++ b/src/test/com/artipie/conda/meta/JsonMaidTest.java
@@ -8,11 +8,12 @@ import com.artipie.asto.test.TestResource;
 import com.fasterxml.jackson.core.JsonFactory;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import org.cactoos.set.SetOf;
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.core.IsEqual;
+import org.json.JSONException;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 /**
  * Test for {@link JsonMaid.Jackson}.
@@ -22,7 +23,7 @@ import org.junit.jupiter.api.Test;
 class JsonMaidTest {
 
     @Test
-    void removedPackages() throws IOException {
+    void removesPackages() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -35,25 +36,18 @@ class JsonMaidTest {
                 "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e"
             )
         );
-        final String actual = stream.toString();
-        MatcherAssert.assertThat(
-            actual,
-            new IsEqual<>(
-                String.join(
-                    "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s", this.cram(), this.decorator()),
-                    "  },",
-                    "  \"packages.conda\" : {",
-                    this.tenacity(),
-                    "  }",
-                    "}"
-                )
-            )
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("JsonMaidTest/removesPackages.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void removesLastPackage() throws IOException {
+    void removesLastPackage() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -61,23 +55,18 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(new SetOf<>("47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"));
-        MatcherAssert.assertThat(
-            stream.toString(),
-            new IsEqual<>(
-                String.join(
-                    "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s,\n%s", this.cram(), this.decorator(), this.pyqt()),
-                    "  },",
-                    "  \"packages.conda\" : {",
-                    this.notebook(),
-                    "  }", "}"
-                )
-            )
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("JsonMaidTest/removesLastPackage.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void removesFirstPackage() throws IOException {
+    void removesFirstPackage() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -85,23 +74,18 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(new SetOf<>("4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08"));
-        MatcherAssert.assertThat(
-            stream.toString(),
-            new IsEqual<>(
-                String.join(
-                    "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s", this.decorator(), this.pyqt()),
-                    "  },",
-                    "  \"packages.conda\" : {",
-                    String.format("%s,\n%s", this.notebook(), this.tenacity()),
-                    "  }", "}"
-                )
-            )
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("JsonMaidTest/removesFirstPackage.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void removesAllTarPackages() throws IOException {
+    void removesAllTarPackages() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -115,21 +99,18 @@ class JsonMaidTest {
                 "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a"
             )
         );
-        MatcherAssert.assertThat(
-            stream.toString(),
-            new IsEqual<>(
-                String.join(
-                    "\n", "{", "  \"packages\" : { },",
-                    "  \"packages.conda\" : {",
-                    String.format("%s,\n%s", this.notebook(), this.tenacity()),
-                    "  }", "}"
-                )
-            )
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("JsonMaidTest/removesAllTarPackages.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void removesAllCondaPackages() throws IOException {
+    void removesAllCondaPackages() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -142,22 +123,18 @@ class JsonMaidTest {
                 "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f"
             )
         );
-        MatcherAssert.assertThat(
-            stream.toString(),
-            new IsEqual<>(
-                String.join(
-                    "\n", "{", "  \"packages\" : {",
-                    String.format("%s,\n%s,\n%s", this.cram(), this.decorator(), this.pyqt()),
-                    "  },",
-                    "  \"packages.conda\" : { }",
-                    "}"
-                )
-            )
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("JsonMaidTest/removesAllCondaPackages.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void doesNothingIfPackageDoesNotExists() throws IOException {
+    void doesNothingIfPackageDoesNotExists() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -165,14 +142,15 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(new SetOf<String>("098"));
-        MatcherAssert.assertThat(
-            stream.toByteArray(),
-            new IsEqual<>(resource.asBytes())
+        JSONAssert.assertEquals(
+            new String(resource.asBytes(), StandardCharsets.UTF_8),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 
     @Test
-    void doesNothingIfChecksumsAreEmpty() throws IOException {
+    void doesNothingIfChecksumsAreEmpty() throws IOException, JSONException {
         final ByteArrayOutputStream stream = new ByteArrayOutputStream();
         final JsonFactory factory = new JsonFactory();
         final TestResource resource = new TestResource("repodata.json");
@@ -180,125 +158,10 @@ class JsonMaidTest {
             factory.createGenerator(stream).useDefaultPrettyPrinter(),
             factory.createParser(resource.asInputStream())
         ).clean(Collections.emptySet());
-        MatcherAssert.assertThat(
-            stream.toByteArray(),
-            new IsEqual<>(resource.asBytes())
-        );
-    }
-
-    private String cram() {
-        return String.join(
-            "\n",
-            "    \"cram-0.7-py36_1.tar.bz2\" : {",
-            "      \"build\" : \"py36_1\",",
-            "      \"build_number\" : 1,",
-            "      \"depends\" : [ \"python >=3.6,<3.7.0a0\" ],",
-            "      \"license\" : \"GPL-2.0\",",
-            "      \"license_family\" : \"GPL2\",",
-            "      \"md5\" : \"609e6545899d1d098f4160dd98fbc74d\",",
-            "      \"name\" : \"cram\",",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08\",",
-            "      \"size\" : 40151,",
-            "      \"subdir\" : \"linux-64\",",
-            "      \"timestamp\" : 1539182927005,",
-            "      \"version\" : \"0.7\"",
-            "    }"
-        );
-    }
-
-    private String decorator() {
-        return String.join(
-            "\n",
-            "    \"decorator-4.2.1-py27_0.tar.bz2\" : {",
-            "      \"build\" : \"py27_0\",",
-            "      \"build_number\" : 0,",
-            "      \"depends\" : [ \"python >=2.7,<2.8.0a0\" ],",
-            "      \"license\" : \"BSD 3-Clause\",",
-            "      \"md5\" : \"0ebe0cb0d62eae6cd237444ba8fded66\",",
-            "      \"name\" : \"decorator\",",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14\",",
-            "      \"size\" : 15638,",
-            "      \"subdir\" : \"linux-64\",",
-            "      \"timestamp\" : 1516376429792,",
-            "      \"version\" : \"4.2.1\"",
-            "    }"
-        );
-    }
-
-    private String pyqt() {
-        return String.join(
-            "\n",
-            "    \"pyqt-5.6.0-py36h0386399_5.tar.bz2\" : {",
-            "      \"build\" : \"py36h0386399_5\",",
-            "      \"build_number\" : 5,",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"depends\" : [ \"dbus >=1.10.22,<2.0a0\", \"libgcc-ng >=7.2.0\", \"libstdcxx-ng >=7.2.0\", \"python >=3.6,<3.7.0a0\", \"qt 5.6.*\", \"sip 4.18.*\" ],",
-            "      \"license\" : \"Commercial, GPL-2.0, GPL-3.0\",",
-            "      \"license_family\" : \"GPL\",",
-            "      \"md5\" : \"b1624f76a6bba705869f849f7456bd39\",",
-            "      \"name\" : \"pyqt\",",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a\",",
-            "      \"size\" : 5715107,",
-            "      \"subdir\" : \"linux-64\",",
-            "      \"timestamp\" : 1505739175210,",
-            "      \"version\" : \"5.6.0\"",
-            "    }"
-        );
-    }
-
-    private String notebook() {
-        return String.join(
-            "\n",
-            "    \"notebook-6.1.1-py38_0.conda\" : {",
-            "      \"app_cli_opts\" : [ {",
-            "        \"args\" : \"--port %s\",",
-            "        \"default\" : \"8080\",",
-            "        \"name\" : \"port\",",
-            "        \"summary\" : \"Server port ...\"",
-            "      } ],",
-            "      \"app_entry\" : \"jupyter-notebook\",",
-            "      \"app_type\" : \"web\",",
-            "      \"build\" : \"py38_0\",",
-            "      \"build_number\" : 0,",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"depends\" : [ \"argon2-cffi\", \"ipykernel\", \"ipython_genutils\", \"jinja2\", \"send2trash\", \"terminado >=0.8.1\", \"tornado >=5.0\", \"traitlets >=4.2.1\" ],",
-            "      \"icon\" : \"df7feebede9861a203b480c119e38b49.png\",",
-            "      \"license\" : \"BSD-3-Clause\",",
-            "      \"license_family\" : \"BSD\",",
-            "      \"md5\" : \"0a90b675d8e46db6dd92b48f085df274\",",
-            "      \"name\" : \"notebook\",",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e\",",
-            "      \"size\" : 4233953,",
-            "      \"subdir\" : \"linux-64\",",
-            "      \"summary\" : \"Jupyter Notebook\",",
-            "      \"timestamp\" : 1596838674769,",
-            "      \"type\" : \"app\",",
-            "      \"version\" : \"6.1.1\"",
-            "    }"
-        );
-    }
-
-    private String tenacity() {
-        return String.join(
-            "\n",
-            "    \"tenacity-6.2.0-py37_0.conda\" : {",
-            "      \"build\" : \"py37_0\",",
-            "      \"build_number\" : 0,",
-            "      \"depends\" : [ \"python >=3.7,<3.8.0a0\", \"six >=1.9.0\" ],",
-            "      \"license\" : \"Apache 2.0\",",
-            "      \"md5\" : \"e5a8af970f391f432c96b1480f535c43\",",
-            "      \"name\" : \"tenacity\",",
-            // @checkstyle LineLengthCheck (1 line)
-            "      \"sha256\" : \"47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f\",",
-            "      \"size\" : 40072,",
-            "      \"subdir\" : \"linux-64\",",
-            "      \"timestamp\" : 1597706734992,",
-            "      \"version\" : \"6.2.0\"",
-            "    }"
+        JSONAssert.assertEquals(
+            new String(resource.asBytes(), StandardCharsets.UTF_8),
+            stream.toString(StandardCharsets.UTF_8.name()),
+            true
         );
     }
 

--- a/src/test/resources-binary/JsonMaidTest/removesAllCondaPackages.json
+++ b/src/test/resources-binary/JsonMaidTest/removesAllCondaPackages.json
@@ -1,0 +1,47 @@
+{
+  "packages" : {
+    "cram-0.7-py36_1.tar.bz2" : {
+      "build" : "py36_1",
+      "build_number" : 1,
+      "depends" : [ "python >=3.6,<3.7.0a0" ],
+      "license" : "GPL-2.0",
+      "license_family" : "GPL2",
+      "md5" : "609e6545899d1d098f4160dd98fbc74d",
+      "name" : "cram",
+      "sha256" : "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+      "size" : 40151,
+      "subdir" : "linux-64",
+      "timestamp" : 1539182927005,
+      "version" : "0.7"
+    },
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    },
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+  }
+}

--- a/src/test/resources-binary/JsonMaidTest/removesAllTarPackages.json
+++ b/src/test/resources-binary/JsonMaidTest/removesAllTarPackages.json
@@ -1,0 +1,43 @@
+{
+  "packages" : { },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    },
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}

--- a/src/test/resources-binary/JsonMaidTest/removesFirstPackage.json
+++ b/src/test/resources-binary/JsonMaidTest/removesFirstPackage.json
@@ -1,0 +1,71 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    },
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    },
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}

--- a/src/test/resources-binary/JsonMaidTest/removesLastPackage.json
+++ b/src/test/resources-binary/JsonMaidTest/removesLastPackage.json
@@ -1,0 +1,72 @@
+{
+  "packages" : {
+    "cram-0.7-py36_1.tar.bz2" : {
+      "build" : "py36_1",
+      "build_number" : 1,
+      "depends" : [ "python >=3.6,<3.7.0a0" ],
+      "license" : "GPL-2.0",
+      "license_family" : "GPL2",
+      "md5" : "609e6545899d1d098f4160dd98fbc74d",
+      "name" : "cram",
+      "sha256" : "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+      "size" : 40151,
+      "subdir" : "linux-64",
+      "timestamp" : 1539182927005,
+      "version" : "0.7"
+    },
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    },
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    }
+  }
+}

--- a/src/test/resources-binary/JsonMaidTest/removesPackages.json
+++ b/src/test/resources-binary/JsonMaidTest/removesPackages.json
@@ -1,0 +1,46 @@
+{
+  "packages" : {
+    "cram-0.7-py36_1.tar.bz2" : {
+      "build" : "py36_1",
+      "build_number" : 1,
+      "depends" : [ "python >=3.6,<3.7.0a0" ],
+      "license" : "GPL-2.0",
+      "license_family" : "GPL2",
+      "md5" : "609e6545899d1d098f4160dd98fbc74d",
+      "name" : "cram",
+      "sha256" : "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+      "size" : 40151,
+      "subdir" : "linux-64",
+      "timestamp" : 1539182927005,
+      "version" : "0.7"
+    },
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  },
+  "packages.conda" : {
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}

--- a/src/test/resources-binary/repodata.json
+++ b/src/test/resources-binary/repodata.json
@@ -1,43 +1,85 @@
 {
   "packages" : {
-    "super-fun-package-0.1.0-py37_0.tar.bz2" : {
-      "build" : "py37_0",
-      "build_number" : 0,
-      "depends" : [ "some-depends" ],
-      "license" : "BSD",
-      "md5" : "a75683f8d9f5b58c19a8ec5d0b7f796e",
-      "name" : "super-fun-package",
-      "sha256" : "1fe3c3f4250e51886838e8e0287e39029d601b9f493ea05c37a2630a9fe5810f",
-      "size" : 3832,
-      "subdir" : "win-64",
-      "timestamp" : 1530731681870,
-      "version" : "0.1.0"
+    "cram-0.7-py36_1.tar.bz2" : {
+      "build" : "py36_1",
+      "build_number" : 1,
+      "depends" : [ "python >=3.6,<3.7.0a0" ],
+      "license" : "GPL-2.0",
+      "license_family" : "GPL2",
+      "md5" : "609e6545899d1d098f4160dd98fbc74d",
+      "name" : "cram",
+      "sha256" : "4b36cb59651f6218449bd71a7d37182f062f545240b502eebed319f77fa54b08",
+      "size" : 40151,
+      "subdir" : "linux-64",
+      "timestamp" : 1539182927005,
+      "version" : "0.7"
     },
-    "test-package-0.5.0-py36_0.conda" : {
-      "build" : "py37_0",
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
       "build_number" : 0,
-      "depends" : [ "some-depends" ],
-      "license" : "BSD",
-      "md5" : "a75683f8d9f5b58c19a8ec5d0b7f786e",
-      "name" : "test-package",
-      "sha256" : "1fe3c3f4250e51886838e8e0287e39076d601b9f493ea05c37a2630a9fe5810f",
-      "size" : 123,
-      "subdir" : "macOS",
-      "timestamp" : 153073163434,
-      "version" : "0.5.0"
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
     },
-    "super-fun-package-0.2.0-py37_0.tar.bz2" : {
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    },
+    "tenacity-6.2.0-py37_0.conda" : {
       "build" : "py37_0",
       "build_number" : 0,
-      "depends" : [ "some-depends" ],
-      "license" : "BSD",
-      "md5" : "abc123",
-      "name" : "super-fun-package",
-      "sha256" : "xyx123",
-      "size" : 3832,
-      "subdir" : "win-64",
-      "timestamp" : 1530731681870,
-      "version" : "0.2.0"
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
     }
   }
 }


### PR DESCRIPTION
Part of #5 
It appears that .tar.bz2 and .conda packages are separated, the `repodata.json` format is:
```
{ 
  packages: { \\all tar.bz2 packages listed here\\ },
  packages.conda: { \\all .conda packages listed here\\ }
}
```
I've updated readme, corrected classes and tests.