### PR TITLE
Implemented case with existing repodata in `MergedJson.Jackson`

### DIFF
--- a/src/main/java/com/artipie/conda/meta/MergedJson.java
+++ b/src/main/java/com/artipie/conda/meta/MergedJson.java
@@ -6,12 +6,14 @@ package com.artipie.conda.meta;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.json.JsonObject;
-import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Merges provided metadata list with existing repodata.json.
@@ -31,6 +33,26 @@ public interface MergedJson {
      * @since 0.2
      */
     final class Jackson implements MergedJson {
+
+        /**
+         * Json object name `packages`.
+         */
+        private static final String PACKAGES = "packages";
+
+        /**
+         * Tar packages extension.
+         */
+        private static final String TAR = ".tar.bz2";
+
+        /**
+         * Json object name `packages.conda`.
+         */
+        private static final String PACKAGES_CONDA = "packages.conda";
+
+        /**
+         * Conda packages extension.
+         */
+        private static final String CONDA = ".conda";
 
         /**
          * Json generator.
@@ -53,30 +75,114 @@ public interface MergedJson {
         }
 
         @Override
+        @SuppressWarnings("PMD.AssignmentInOperand")
         public void merge(final Map<String, JsonObject> items) throws IOException {
             if (this.parser.isPresent()) {
-                throw new NotImplementedException("To be implemented");
+                final JsonParser prsr = this.parser.get();
+                JsonToken token;
+                final AtomicReference<Boolean> tars = new AtomicReference<>(false);
+                final AtomicReference<Boolean> condas = new AtomicReference<>(false);
+                while ((token = prsr.nextToken()) != null) {
+                    // @checkstyle NestedIfDepthCheck (10 lines)
+                    if (token == JsonToken.END_OBJECT) {
+                        // @checkstyle InnerAssignmentCheck (1 line)
+                        if ((token = prsr.nextToken()) != null) {
+                            this.gnrt.writeEndObject();
+                            this.processJsonToken(items, prsr, token, tars, condas);
+                        }
+                    } else {
+                        this.processJsonToken(items, prsr, token, tars, condas);
+                    }
+                }
+                if (!tars.get()) {
+                    this.writePackagesItem(items, Jackson.PACKAGES, Jackson.TAR);
+                }
+                if (!condas.get()) {
+                    this.writePackagesItem(items, Jackson.PACKAGES_CONDA, Jackson.CONDA);
+                }
             } else {
                 this.gnrt.writeStartObject();
-                this.gnrt.writeFieldName("packages");
-                this.gnrt.writeStartObject();
-                this.writePackages(items, ".tar.bz2");
-                this.gnrt.writeEndObject();
-                this.gnrt.writeFieldName("packages.conda");
-                this.gnrt.writeStartObject();
-                this.writePackages(items, ".conda");
-                this.gnrt.writeEndObject();
+                this.writePackagesItem(items, Jackson.PACKAGES, Jackson.TAR);
+                this.writePackagesItem(items, Jackson.PACKAGES_CONDA, Jackson.CONDA);
             }
             this.gnrt.close();
         }
 
         /**
-         * Writes packages (.tar.bz2 or .conda) to json generator.
+         * Processes current json token.
+         * @param items Packages items to append
+         * @param prsr Json parser
+         * @param token Current token
+         * @param tars Is it json object with .tar.bz2 items?
+         * @param condas Is it json object with .conda items?
+         * @throws IOException On IO error
+         * @checkstyle ParameterNumberCheck (5 lines)
+         */
+        private void processJsonToken(final Map<String, JsonObject> items, final JsonParser prsr,
+            final JsonToken token, final AtomicReference<Boolean> tars,
+            final AtomicReference<Boolean> condas) throws IOException {
+            if (token == JsonToken.FIELD_NAME && Jackson.PACKAGES.equals(prsr.getCurrentName())) {
+                this.appendNewPackages(items, prsr, Jackson.TAR);
+                tars.set(true);
+            } else if (token == JsonToken.FIELD_NAME
+                && Jackson.PACKAGES_CONDA.equals(prsr.getCurrentName())) {
+                this.appendNewPackages(items, prsr, Jackson.CONDA);
+                condas.set(true);
+            } else if (token == JsonToken.FIELD_NAME
+                && (prsr.getCurrentName().endsWith(Jackson.TAR)
+                || prsr.getCurrentName().endsWith(Jackson.CONDA))) {
+                final String name = prsr.getCurrentName();
+                prsr.nextToken();
+                prsr.setCodec(new ObjectMapper());
+                final ObjectNode nodes = prsr.<ObjectNode>readValueAsTree();
+                if (!items.containsKey(name)) {
+                    this.gnrt.writeFieldName(name);
+                    this.gnrt.setCodec(new ObjectMapper());
+                    this.gnrt.writeTree(nodes);
+                }
+            } else {
+                this.gnrt.copyCurrentEvent(prsr);
+            }
+        }
+
+        /**
+         * Writes `packages` or `packages.conda` json object element with the list of the new
+         * packages.
+         * @param items Packages to write
+         * @param name Json object name: `packages` or `packages.conda`
+         * @param type Packages type to write
+         * @throws IOException On IO error
+         */
+        private void writePackagesItem(final Map<String, JsonObject> items,
+            final String name, final String type) throws IOException {
+            this.gnrt.writeFieldName(name);
+            this.gnrt.writeStartObject();
+            this.writeNewPackages(items, type);
+            this.gnrt.writeEndObject();
+        }
+
+        /**
+         * Appends new packages to existing repodata.json.
+         * @param items Items to add
+         * @param prsr Json parser
+         * @param type Packages type
+         * @throws IOException On IO error
+         */
+        private void appendNewPackages(final Map<String, JsonObject> items,
+            final JsonParser prsr, final String type) throws IOException {
+            this.gnrt.copyCurrentEvent(prsr);
+            prsr.nextToken();
+            this.gnrt.copyCurrentEvent(prsr);
+            this.writeNewPackages(items, type);
+        }
+
+        /**
+         * Writes new packages (.tar.bz2 or .conda) to json generator.
          * @param items Items to write
          * @param type Packages type
          * @throws IOException On IO error
          */
-        private void writePackages(final Map<String, JsonObject> items, final String type)
+        private void writeNewPackages(final Map<String, JsonObject> items, final String type)
             throws IOException {
             for (final String pckg : items.keySet()) {
                 if (pckg.endsWith(type)) {

--- a/src/test/java/com/artipie/conda/meta/MergedJsonTest.java
+++ b/src/test/java/com/artipie/conda/meta/MergedJsonTest.java
@@ -96,6 +96,32 @@ class MergedJsonTest {
         );
     }
 
+    @Test
+    void mergesPackage() throws IOException, JSONException {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        final JsonFactory factory = new JsonFactory();
+        new MergedJson.Jackson(
+            factory.createGenerator(res).useDefaultPrettyPrinter(),
+            Optional.of(
+                factory.createParser(
+                    new TestResource("MergedJsonTest/mergesTarPackages_input.json").asInputStream()
+                )
+            )
+        ).merge(
+            new MapOf<String, JsonObject>(
+                this.packageItem("pyqt-5.6.0-py36h0386399_5.tar.bz2", "pyqt-tar.json")
+            )
+        );
+        JSONAssert.assertEquals(
+            new String(
+                new TestResource("MergedJsonTest/mergesTarPackages_output.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            res.toString(StandardCharsets.UTF_8.name()),
+            true
+        );
+    }
+
     private MapEntry<String, JsonObject> packageItem(final String filename, final String resourse) {
         return new MapEntry<String, JsonObject>(
             filename,

--- a/src/test/resources-binary/MergedJsonTest/mergesTarPackages_input.json
+++ b/src/test/resources-binary/MergedJsonTest/mergesTarPackages_input.json
@@ -1,0 +1,32 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  },
+  "packages.conda" : {
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}

--- a/src/test/resources-binary/MergedJsonTest/mergesTarPackages_output.json
+++ b/src/test/resources-binary/MergedJsonTest/mergesTarPackages_output.json
@@ -1,0 +1,46 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    },
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}


### PR DESCRIPTION
Part of #5 
Implemented case with existing repodata in `MergedJson.Jackson` and added one test case (will add more in the next PR). Implementation is complex due to several possible scenarios and jackson API peculiarities. Repodata file looks like:
```
{
  "packages": {
    //tar.bz2 packages listed here//
  },
  "packages.conda": {
    //conda packages listed here//
  }
}
```
Either "packages" or "packages.conda" can be absent, in that case we have to add the absent element. To add this absent element, it is necessary not to write last closing } from the parser. Jackson parser does not have `boolen hasNext()` method, it is only possible to take the next element with `nextToken()` method. So, to distinguish this last } from other } I have to check the next item with the nested ifs and process the obtained token accordingly. 

Hope my explanation is understandable, if there will be any ideas for simplifying, please, share.