### PR TITLE
Added more tests for `MergedJson.Jackson`

### DIFF
--- a/src/test/java/com/artipie/conda/meta/MergedJsonTest.java
+++ b/src/test/java/com/artipie/conda/meta/MergedJsonTest.java
@@ -106,7 +106,8 @@ class MergedJsonTest {
         "mp3_input.json,notebook-6.1.1-py38_0.conda,notebook-conda.json,mp3_output.json",
         "mp4_input.json,decorator-4.2.1-py27_0.tar.bz2,decorator-tar.json,mp4_output.json",
         "mp5_input.json,decorator-4.2.1-py27_0.tar.bz2,decorator-tar.json,mp3_output.json",
-        "mp6_input.json,notebook-6.1.1-py38_0.conda,notebook-conda.json,mp3_output.json"
+        "mp6_input.json,notebook-6.1.1-py38_0.conda,notebook-conda.json,mp3_output.json",
+        "mp7_input.json,decorator-4.2.1-py27_0.tar.bz2,decorator-tar.json,mp7_output.json"
     })
     // @checkstyle ParameterNumberCheck (5 lines)
     void mergesPackage(final String input, final String pkg, final String file, final String out)
@@ -142,7 +143,8 @@ class MergedJsonTest {
         "mps4_input.json,mps4_output.json",
         "mps5_input.json,mps5_output.json",
         "mps6_input.json,mps6_output.json",
-        "mps7_input.json,mps6_output.json"
+        "mps7_input.json,mps6_output.json",
+        "mps8_input.json,mps6_output.json"
     })
     void mergesPackages(final String input, final String out) throws IOException, JSONException {
         final ByteArrayOutputStream res = new ByteArrayOutputStream();

--- a/src/test/resources-binary/MergedJsonTest/mp7_input.json
+++ b/src/test/resources-binary/MergedJsonTest/mp7_input.json
@@ -1,0 +1,17 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "abc123",
+      "name" : "decorator",
+      "sha256" : "xyz098",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  }
+}

--- a/src/test/resources-binary/MergedJsonTest/mp7_output.json
+++ b/src/test/resources-binary/MergedJsonTest/mp7_output.json
@@ -1,0 +1,18 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  },
+  "packages.conda" : {}
+}

--- a/src/test/resources-binary/MergedJsonTest/mps8_input.json
+++ b/src/test/resources-binary/MergedJsonTest/mps8_input.json
@@ -1,0 +1,39 @@
+{
+  "packages" : {
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0"],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "abc123",
+      "name" : "pyqt",
+      "sha256" : "xyz098",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi"],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "abc123",
+      "name" : "notebook",
+      "sha256" : "xyz098",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    }
+  }
+}


### PR DESCRIPTION
Part of #5 
I've added missed tests for `MergedJson.Jackson` for the case with duplicates packages (duplicates are checked by package name, we write new versions instead of the one present in repodata.json).