### PR TITLE
`MultiRepodata.Unique` implemented

### DIFF
--- a/src/main/java/com/artipie/conda/MultiRepodata.java
+++ b/src/main/java/com/artipie/conda/MultiRepodata.java
@@ -4,24 +4,37 @@
  */
 package com.artipie.conda;
 
+import com.artipie.asto.ArtipieIOException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collection;
-import org.apache.commons.lang3.NotImplementedException;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
- * Multi conda repodata: merges repodata (possibly obtained from different remotes) into single
- * repodata index.
+ * Multi conda repodata: merges repodata (possibly obtained from different remotes)
+ * into single repodata index.
  * @since 0.3
  */
 public interface MultiRepodata {
 
     /**
      * Merges repodata.jsons into single repodata.json.
-     * @param input Collections of repodata.json to merge
+     * @param inputs Collections of repodata.json to merge
      * @param result Where to write the result
      */
-    void merge(Collection<InputStream> input, OutputStream result);
+    void merge(Collection<InputStream> inputs, OutputStream result);
 
     /**
      * Implementation of {@link MultiRepodata} that merges Repodata.json indexes checking for
@@ -32,11 +45,123 @@ public interface MultiRepodata {
      * the outside.
      * @since 0.3
      */
-    class Unique implements MultiRepodata {
+    final class Unique implements MultiRepodata {
 
+        /**
+         * Temp file extension.
+         */
+        private static final String EXT = "json";
+
+        /**
+         * Repodata.json field name "packages.conda".
+         */
+        private static final String FIELD = "packages.conda";
+
+        /**
+         * Filenames of the packages.
+         */
+        private final Set<String> pckgs = new HashSet<>();
+
+        // @checkstyle ExecutableStatementCountCheck (30 lines)
         @Override
-        public void merge(final Collection<InputStream> input, final OutputStream result) {
-            throw new NotImplementedException("Not implemented yet");
+        public void merge(final Collection<InputStream> inputs, final OutputStream result) {
+            final JsonFactory factory = new JsonFactory();
+            try {
+                final Path ftars = Files.createTempFile("tars", Unique.EXT);
+                final Path fcondas = Files.createTempFile("condas", Unique.EXT);
+                // @checkstyle NestedTryDepthCheck (20 lines)
+                try {
+                    try (
+                        OutputStream otars = new BufferedOutputStream(Files.newOutputStream(ftars));
+                        OutputStream ocondas =
+                            new BufferedOutputStream(Files.newOutputStream(fcondas))
+                    ) {
+                        final JsonGenerator tars = factory.createGenerator(otars);
+                        final JsonGenerator condas = factory.createGenerator(ocondas);
+                        tars.writeStartObject();
+                        condas.writeStartObject();
+                        for (final InputStream item : inputs) {
+                            this.processInput(factory.createParser(item), tars, condas);
+                        }
+                        tars.close();
+                        condas.close();
+                    }
+                    try (
+                        InputStream itars = new BufferedInputStream(Files.newInputStream(ftars));
+                        InputStream icondas = new BufferedInputStream(Files.newInputStream(fcondas))
+                    ) {
+                        final JsonGenerator res = factory.createGenerator(result);
+                        res.writeStartObject();
+                        Unique.writePackages(factory.createParser(itars), res, "packages");
+                        Unique.writePackages(factory.createParser(icondas), res, Unique.FIELD);
+                        res.writeEndObject();
+                        res.close();
+                    }
+                } finally {
+                    Files.delete(ftars);
+                    Files.delete(fcondas);
+                }
+            } catch (final IOException err) {
+                throw new ArtipieIOException(err);
+            }
+        }
+
+        /**
+         * Processes input (packages.json) by writing unique packages info into temp
+         * outputs.
+         * @param parser Parser input
+         * @param tars Output for tars packages
+         * @param condas Output for condas packages
+         * @throws IOException On IO error
+         */
+        @SuppressWarnings("PMD.AssignmentInOperand")
+        private void processInput(final JsonParser parser, final JsonGenerator tars,
+            final JsonGenerator condas) throws IOException {
+            JsonToken token;
+            while ((token = parser.nextToken()) != null) {
+                if (token == JsonToken.FIELD_NAME
+                    && !Unique.FIELD.equals(parser.getCurrentName())
+                    && parser.getCurrentName().endsWith(".conda")) {
+                    this.writeItem(parser, condas);
+                } else if (token == JsonToken.FIELD_NAME
+                    && parser.getCurrentName().endsWith(".tar.bz2")) {
+                    this.writeItem(parser, tars);
+                }
+            }
+        }
+
+        /**
+         * Writes package item from parser to the resulting output (JsonGenerator).
+         * @param parser Where to read from
+         * @param generator Where to write
+         * @throws IOException On IO error
+         */
+        private void writeItem(final JsonParser parser, final JsonGenerator generator)
+            throws IOException {
+            final String name = parser.getCurrentName();
+            parser.nextToken();
+            parser.setCodec(new ObjectMapper());
+            final ObjectNode nodes = parser.<ObjectNode>readValueAsTree();
+            if (this.pckgs.add(name)) {
+                generator.writeFieldName(name);
+                generator.setCodec(new ObjectMapper());
+                generator.writeTree(nodes);
+            }
+        }
+
+        /**
+         * Writes pacckages to the resulting file.
+         * @param parser Parser to write and parse
+         * @param res Where to write the result
+         * @param field Field name
+         * @throws IOException On IO error
+         */
+        private static void writePackages(final JsonParser parser, final JsonGenerator res,
+            final String field) throws IOException {
+            res.writeFieldName(field);
+            while (parser.nextToken() != null) {
+                res.copyCurrentEvent(parser);
+            }
         }
     }
 }

--- a/src/test/java/com/artipie/conda/MultiRepodataUniqueTest.java
+++ b/src/test/java/com/artipie/conda/MultiRepodataUniqueTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/conda-adapter/LICENSE
+ */
+package com.artipie.conda;
+
+import com.artipie.asto.test.TestResource;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import org.cactoos.list.ListOf;
+import org.json.JSONException;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+/**
+ * Test for {@link MultiRepodata.Unique}.
+ * @since 0.3
+ */
+class MultiRepodataUniqueTest {
+
+    @Test
+    void mergesPackages() throws UnsupportedEncodingException, JSONException {
+        final ByteArrayOutputStream res = new ByteArrayOutputStream();
+        new MultiRepodata.Unique().merge(
+            new ListOf<InputStream>(
+                new TestResource("MultiRepodataUniqueTest/mergesPackages_input1.json")
+                    .asInputStream(),
+                new TestResource("MultiRepodataUniqueTest/mergesPackages_input2.json")
+                    .asInputStream()
+            ),
+            res
+        );
+        JSONAssert.assertEquals(
+            res.toString(StandardCharsets.UTF_8.name()),
+            new String(
+                new TestResource("MultiRepodataUniqueTest/mergesPackages_res.json").asBytes(),
+                StandardCharsets.UTF_8
+            ),
+            true
+        );
+    }
+}

--- a/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_input1.json
+++ b/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_input1.json
@@ -1,0 +1,32 @@
+{
+  "packages" : {
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  },
+  "packages.conda" : {
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    }
+  }
+}

--- a/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_input2.json
+++ b/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_input2.json
@@ -1,0 +1,45 @@
+{
+  "packages" : {
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    }
+  },
+  "packages.conda" : {
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    }
+  }
+}

--- a/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_res.json
+++ b/src/test/resources-binary/MultiRepodataUniqueTest/mergesPackages_res.json
@@ -1,0 +1,71 @@
+{
+  "packages" : {
+    "pyqt-5.6.0-py36h0386399_5.tar.bz2" : {
+      "build" : "py36h0386399_5",
+      "build_number" : 5,
+      "depends" : [ "dbus >=1.10.22,<2.0a0", "libgcc-ng >=7.2.0", "libstdcxx-ng >=7.2.0", "python >=3.6,<3.7.0a0", "qt 5.6.*", "sip 4.18.*" ],
+      "license" : "Commercial, GPL-2.0, GPL-3.0",
+      "license_family" : "GPL",
+      "md5" : "b1624f76a6bba705869f849f7456bd39",
+      "name" : "pyqt",
+      "sha256" : "b37f144a5c2349b1c58ef17a663cb79086a1f2f49e35503e4f411f6f698cee1a",
+      "size" : 5715107,
+      "subdir" : "linux-64",
+      "timestamp" : 1505739175210,
+      "version" : "5.6.0"
+    },
+    "decorator-4.2.1-py27_0.tar.bz2" : {
+      "build" : "py27_0",
+      "build_number" : 0,
+      "depends" : [ "python >=2.7,<2.8.0a0" ],
+      "license" : "BSD 3-Clause",
+      "md5" : "0ebe0cb0d62eae6cd237444ba8fded66",
+      "name" : "decorator",
+      "sha256" : "b5f77880181b37fb2e180766869da6242648aaec5bdd6de89296d9dacd764c14",
+      "size" : 15638,
+      "subdir" : "linux-64",
+      "timestamp" : 1516376429792,
+      "version" : "4.2.1"
+    }
+  },
+  "packages.conda" : {
+    "tenacity-6.2.0-py37_0.conda" : {
+      "build" : "py37_0",
+      "build_number" : 0,
+      "depends" : [ "python >=3.7,<3.8.0a0", "six >=1.9.0" ],
+      "license" : "Apache 2.0",
+      "md5" : "e5a8af970f391f432c96b1480f535c43",
+      "name" : "tenacity",
+      "sha256" : "47d6dd01a1cff52af31804bbfffb4341fd8676c75d00d120cc66d9709e78ea7f",
+      "size" : 40072,
+      "subdir" : "linux-64",
+      "timestamp" : 1597706734992,
+      "version" : "6.2.0"
+    },
+    "notebook-6.1.1-py38_0.conda" : {
+      "app_cli_opts" : [ {
+        "args" : "--port %s",
+        "default" : "8080",
+        "name" : "port",
+        "summary" : "Server port ..."
+      } ],
+      "app_entry" : "jupyter-notebook",
+      "app_type" : "web",
+      "build" : "py38_0",
+      "build_number" : 0,
+      "depends" : [ "argon2-cffi", "ipykernel", "ipython_genutils", "jinja2", "send2trash", "terminado >=0.8.1", "tornado >=5.0", "traitlets >=4.2.1" ],
+      "icon" : "df7feebede9861a203b480c119e38b49.png",
+      "license" : "BSD-3-Clause",
+      "license_family" : "BSD",
+      "md5" : "0a90b675d8e46db6dd92b48f085df274",
+      "name" : "notebook",
+      "sha256" : "be2a62bd5a3a6abda7f2309f4f2ddce7bededb40adb91341f18438b246d7fc7e",
+      "size" : 4233953,
+      "subdir" : "linux-64",
+      "summary" : "Jupyter Notebook",
+      "timestamp" : 1596838674769,
+      "type" : "app",
+      "version" : "6.1.1"
+    }
+  }
+}


### PR DESCRIPTION
Part of #26 
Implemented `MultiRepodata.Unique` and added simple test (will add more tests in the next PR). 
Here is repodata.json structure:
```
{
  "packages": {
    //tar.bz2 packages listed here//
  },
  "packages.conda": {
    //conda packages listed here//
  }
}
```
The order of the "packages" and "packages.conda" items in repodata.json is not specified in the documentation, thus there is no way to avoid writing "packages" and "packages.conda" in the different temp files.