### PR TITLE
Added `DownloadRepodataSlice`

### DIFF
--- a/src/main/java/com/artipie/conda/http/CondaSlice.java
+++ b/src/main/java/com/artipie/conda/http/CondaSlice.java
@@ -13,6 +13,7 @@ import com.artipie.http.auth.Permission;
 import com.artipie.http.auth.Permissions;
 import com.artipie.http.rq.RqMethod;
 import com.artipie.http.rt.ByMethodsRule;
+import com.artipie.http.rt.RtRule;
 import com.artipie.http.rt.RtRulePath;
 import com.artipie.http.rt.SliceRoute;
 import com.artipie.http.slice.SliceDownload;
@@ -20,6 +21,7 @@ import com.artipie.http.slice.SliceDownload;
 /**
  * Main conda entry point.
  * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class CondaSlice extends Slice.Wrap {
 
@@ -40,6 +42,17 @@ public final class CondaSlice extends Slice.Wrap {
     public CondaSlice(final Storage storage, final Permissions perms, final Authentication users) {
         super(
             new SliceRoute(
+                new RtRulePath(
+                    new RtRule.All(
+                        new RtRule.ByPath(".*repodata\\.json$"),
+                        new ByMethodsRule(RqMethod.GET)
+                    ),
+                    new BasicAuthSlice(
+                        new DownloadRepodataSlice(storage),
+                        users,
+                        new Permission.ByName(perms, Action.Standard.READ)
+                    )
+                ),
                 new RtRulePath(
                     new ByMethodsRule(RqMethod.GET),
                     new BasicAuthSlice(

--- a/src/main/java/com/artipie/conda/http/DownloadRepodataSlice.java
+++ b/src/main/java/com/artipie/conda/http/DownloadRepodataSlice.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/conda-adapter/LICENSE
+ */
+package com.artipie.conda.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Storage;
+import com.artipie.http.Headers;
+import com.artipie.http.Response;
+import com.artipie.http.Slice;
+import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.headers.ContentFileName;
+import com.artipie.http.rq.RequestLineFrom;
+import com.artipie.http.rs.RsFull;
+import com.artipie.http.rs.RsStatus;
+import com.artipie.http.slice.KeyFromPath;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Slice to download repodata.json. If the repodata item does not exists in storage, empty
+ * json is returned.
+ * @since 0.4
+ */
+public final class DownloadRepodataSlice implements Slice {
+
+    /**
+     * Abstract storage.
+     */
+    private final Storage asto;
+
+    /**
+     * Ctor.
+     * @param asto Abstract storage
+     */
+    public DownloadRepodataSlice(final Storage asto) {
+        this.asto = asto;
+    }
+
+    @Override
+    public Response response(final String line, final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body) {
+        return new AsyncResponse(
+            CompletableFuture
+                .supplyAsync(() -> new KeyFromPath(new RequestLineFrom(line).uri().getPath()))
+                .thenCompose(
+                    key -> this.asto.exists(key).thenCompose(
+                        exist -> {
+                            final CompletionStage<Content> content;
+                            if (exist) {
+                                content = this.asto.value(key);
+                            } else {
+                                content = CompletableFuture.completedFuture(
+                                    new Content.From("{}".getBytes(StandardCharsets.US_ASCII))
+                                );
+                            }
+                            return content;
+                        }
+                    ).thenApply(
+                        content -> new RsFull(
+                            RsStatus.OK,
+                            new Headers.From(new ContentFileName(key.toString())), content
+                        )
+                    )
+                )
+        );
+    }
+}

--- a/src/main/java/com/artipie/conda/http/DownloadRepodataSlice.java
+++ b/src/main/java/com/artipie/conda/http/DownloadRepodataSlice.java
@@ -6,6 +6,7 @@ package com.artipie.conda.http;
 
 import com.artipie.asto.Content;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.KeyLastPart;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
@@ -26,6 +27,7 @@ import org.reactivestreams.Publisher;
  * Slice to download repodata.json. If the repodata item does not exists in storage, empty
  * json is returned.
  * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 public final class DownloadRepodataSlice implements Slice {
 
@@ -64,7 +66,8 @@ public final class DownloadRepodataSlice implements Slice {
                     ).thenApply(
                         content -> new RsFull(
                             RsStatus.OK,
-                            new Headers.From(new ContentFileName(key.toString())), content
+                            new Headers.From(new ContentFileName(new KeyLastPart(key).get())),
+                            content
                         )
                     )
                 )

--- a/src/test/java/com/artipie/conda/CondaSliceITCase.java
+++ b/src/test/java/com/artipie/conda/CondaSliceITCase.java
@@ -4,7 +4,6 @@
  */
 package com.artipie.conda;
 
-import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
@@ -89,15 +88,6 @@ public final class CondaSliceITCase {
     void canInstall() throws Exception {
         new TestResource("CondaSliceITCase/packages.json")
             .saveTo(this.storage, new Key.From("linux-64/repodata.json"));
-        this.storage.save(
-            new Key.From("linux-64/current_repodata.json"), new Content.From("{}".getBytes())
-        ).join();
-        this.storage.save(
-            new Key.From("noarch/current_repodata.json"), new Content.From("{}".getBytes())
-        ).join();
-        this.storage.save(
-            new Key.From("noarch/repodata.json"), new Content.From("{}".getBytes())
-        ).join();
         new TestResource("CondaSliceITCase/snappy-1.1.3-0.tar.bz2")
             .saveTo(this.storage, new Key.From("linux-64/snappy-1.1.3-0.tar.bz2"));
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/conda/http/DownloadRepodataSliceTest.java
+++ b/src/test/java/com/artipie/conda/http/DownloadRepodataSliceTest.java
@@ -8,17 +8,22 @@ import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
 import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.headers.ContentDisposition;
+import com.artipie.http.headers.ContentLength;
 import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.RsHasHeaders;
 import com.artipie.http.hm.SliceHasResponse;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
  * Test for {@link DownloadRepodataSlice}.
  * @since 0.4
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 class DownloadRepodataSliceTest {
 
@@ -41,7 +46,13 @@ class DownloadRepodataSliceTest {
         MatcherAssert.assertThat(
             new DownloadRepodataSlice(this.asto),
             new SliceHasResponse(
-                new RsHasBody(bytes),
+                Matchers.allOf(
+                    new RsHasBody(bytes),
+                    new RsHasHeaders(
+                        new ContentDisposition("attachment; filename=\"repodata.json\""),
+                        new ContentLength(bytes.length)
+                    )
+                ),
                 new RequestLine(RqMethod.GET, "/linux-64/repodata.json")
             )
         );
@@ -49,10 +60,17 @@ class DownloadRepodataSliceTest {
 
     @Test
     void returnsEmptyJsonIfNotExists() {
+        final byte[] bytes = "{}".getBytes();
         MatcherAssert.assertThat(
             new DownloadRepodataSlice(this.asto),
             new SliceHasResponse(
-                new RsHasBody("{}".getBytes()),
+                Matchers.allOf(
+                    new RsHasBody(bytes),
+                    new RsHasHeaders(
+                        new ContentDisposition("attachment; filename=\"current_repodata.json\""),
+                        new ContentLength(bytes.length)
+                    )
+                ),
                 new RequestLine(RqMethod.GET, "/noarch/current_repodata.json")
             )
         );

--- a/src/test/java/com/artipie/conda/http/DownloadRepodataSliceTest.java
+++ b/src/test/java/com/artipie/conda/http/DownloadRepodataSliceTest.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/conda-adapter/LICENSE
+ */
+package com.artipie.conda.http;
+
+import com.artipie.asto.Content;
+import com.artipie.asto.Key;
+import com.artipie.asto.Storage;
+import com.artipie.asto.memory.InMemoryStorage;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.hm.SliceHasResponse;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test for {@link DownloadRepodataSlice}.
+ * @since 0.4
+ */
+class DownloadRepodataSliceTest {
+
+    /**
+     * Test storage.
+     */
+    private Storage asto;
+
+    @BeforeEach
+    void init() {
+        this.asto = new InMemoryStorage();
+    }
+
+    @Test
+    void returnsItemFromStorageIfExists() {
+        final byte[] bytes = "data".getBytes();
+        this.asto.save(
+            new Key.From("linux-64/repodata.json"), new Content.From(bytes)
+        ).join();
+        MatcherAssert.assertThat(
+            new DownloadRepodataSlice(this.asto),
+            new SliceHasResponse(
+                new RsHasBody(bytes),
+                new RequestLine(RqMethod.GET, "/linux-64/repodata.json")
+            )
+        );
+    }
+
+    @Test
+    void returnsEmptyJsonIfNotExists() {
+        MatcherAssert.assertThat(
+            new DownloadRepodataSlice(this.asto),
+            new SliceHasResponse(
+                new RsHasBody("{}".getBytes()),
+                new RequestLine(RqMethod.GET, "/noarch/current_repodata.json")
+            )
+        );
+    }
+}

--- a/src/test/java/com/artipie/conda/http/package-info.java
+++ b/src/test/java/com/artipie/conda/http/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
+ * https://github.com/artipie/conda-adapter/LICENSE
+ */
+
+/**
+ * Conda adapter http layer tests.
+ *
+ * @since 0.4
+ */
+package com.artipie.conda.http;


### PR DESCRIPTION
Part of #32 
Added slice to download `repodata.json` items from storage. If the index does not exist, an empty json is returned. Conda client failed installation if `NOT FOUND` is returned in such cases.