### PR TITLE
ci: add benchmarks action, extract folder as a module, bump asto to `v1.8.0`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,55 @@
+name: Run benchmarks
+on:
+  push:
+    tags:
+      - 'test*'
+jobs:
+  running-bench:
+    name: Run benchmark
+    runs-on: [self-hosted, bench]
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - name: Set env
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+          echo "REPO=conda" >> $GITHUB_ENV
+          echo "http_proxy=http://localhost:3128" >> $GITHUB_ENV
+          echo "https_proxy=http://localhost:3128" >> $GITHUB_ENV
+      - name: Run target benchmark
+        run: |
+          git clone https://github.com/artipie/benchmarks.git tmp-bench
+          cd tmp-bench/adapters
+          make run TARGET=${{ env.REPO }}
+          mkdir -p $GITHUB_WORKSPACE/benchmarks/results/${{ env.TAG }}
+          cp -avr out/${{ env.REPO }}/* $GITHUB_WORKSPACE/benchmarks/results/${{ env.TAG }}
+          cd ../..
+          rm -rf tmp-bench
+      - name: Set user and fetch
+        run: |
+          git config --global user.name "github-action"
+          git config --global user.email "benchmarks@artipie.com"
+          git add .
+          git fetch origin
+          git switch -C master origin/master
+          git checkout -b bench-${{ env.TAG }}
+          git commit -m "bench: added results of benchmarks for ${{ env.TAG }}"
+          git push origin HEAD:bench-${{ env.TAG }}
+  pull-request:
+    name: Create PR with results
+    needs: running-bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+      - name: Set env
+        run: |
+          echo "TAG=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Create pull request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: "bench-${{ env.TAG }}"
+          destination_branch: "master"
+          pr_title: "bench: adding results of benchmarks for ${{ env.TAG }}"
+          pr_reviewer: "genryxy"
+          pr_assignee: "genryxy"
+          pr_label: "benchmarks-results"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -29,13 +29,12 @@ SOFTWARE.
     <version>0.5.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <groupId>com.artipie</groupId>
   <artifactId>conda-bench</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <properties>
     <jmh.version>1.29</jmh.version>
-    <asto.version>v1.3.2</asto.version>
+    <asto.version>v1.8.0</asto.version>
   </properties>
   <dependencies>
     <dependency>

--- a/benchmarks/results/README.md
+++ b/benchmarks/results/README.md
@@ -1,0 +1,1 @@
+This folder contains results of benchmarks for different versions of Conda.

--- a/benchmarks/src/main/java/com/artipie/conda/CondaRepodataAppendBench.java
+++ b/benchmarks/src/main/java/com/artipie/conda/CondaRepodataAppendBench.java
@@ -2,9 +2,8 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/conda-adapter/LICENSE
  */
-package com.artipie.conda.benchmarks;
+package com.artipie.conda;
 
-import com.artipie.conda.CondaRepodata;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/benchmarks/src/main/java/com/artipie/conda/CondaRepodataRemoveBench.java
+++ b/benchmarks/src/main/java/com/artipie/conda/CondaRepodataRemoveBench.java
@@ -2,9 +2,8 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/conda-adapter/LICENSE
  */
-package com.artipie.conda.benchmarks;
+package com.artipie.conda;
 
-import com.artipie.conda.CondaRepodata;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/benchmarks/src/main/java/com/artipie/conda/MultiRepodataBench.java
+++ b/benchmarks/src/main/java/com/artipie/conda/MultiRepodataBench.java
@@ -2,9 +2,8 @@
  * The MIT License (MIT) Copyright (c) 2020-2021 artipie.com
  * https://github.com/artipie/conda-adapter/LICENSE
  */
-package com.artipie.conda.benchmarks;
+package com.artipie.conda;
 
-import com.artipie.conda.MultiRepodata;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>v1.6.0</version>
+      <version>v1.8.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Part of artipie/artipie#431
Added benchmarks action, extracted folder with benchmarks as a separate module, bumped asto to `v1.8.0`