### PR TITLE
fix(UpdateSlice): remove slash in temp key

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -13,3 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: g4s8/xcop-action@master
+        with:
+          license: LICENSE

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@ SOFTWARE.
       <timezone>+3</timezone>
     </developer>
   </developers>
+  <contributors>
+    <contributor>
+      <name>Olivier B. OURA</name>
+      <email>baudoliver7@gmail.com</email>
+      <organization>baudoliver7.com</organization>
+      <organizationUrl>https://www.baudoliver7.com</organizationUrl>
+      <roles>
+        <role>Developer</role>
+      </roles>
+      <timezone>+0</timezone>
+    </contributor>
+  </contributors>
   <issueManagement>
     <system>GitHub</system>
     <url>https://github.com/artipie/conda-adapter/issues</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <!--
-The MIT License (MIT)
+MIT License
 
-Copyright (c) 2020 artipie.com
+Copyright (c) 2021 Artipie
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11,12 +11,12 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE

--- a/src/main/java/com/artipie/conda/http/UpdateSlice.java
+++ b/src/main/java/com/artipie/conda/http/UpdateSlice.java
@@ -50,7 +50,7 @@ public final class UpdateSlice implements Slice {
     /**
      * Temporary upload key.
      */
-    private static final Key TMP = new Key.From("./upload");
+    private static final Key TMP = new Key.From("upload");
 
     /**
      * Abstract storage.

--- a/src/main/java/com/artipie/conda/http/UpdateSlice.java
+++ b/src/main/java/com/artipie/conda/http/UpdateSlice.java
@@ -50,7 +50,7 @@ public final class UpdateSlice implements Slice {
     /**
      * Temporary upload key.
      */
-    private static final Key TMP = new Key.From("upload");
+    private static final Key TMP = new Key.From(".upload");
 
     /**
      * Abstract storage.


### PR DESCRIPTION
Given that temporary upload key `TMP` (class `UpdateSlice`) was not a valid key (`./upload`), we simply removed `/`.

Cc: https://github.com/artipie/asto/pull/402#issuecomment-1044465257
Fix: #85
Ref: artipie/artipie#995